### PR TITLE
Check remap when appending kv/info/data

### DIFF
--- a/gguflib.c
+++ b/gguflib.c
@@ -461,7 +461,7 @@ int gguf_append_kv(gguf_ctx *ctx, const char *keyname, uint64_t keylen, uint32_t
     if (write(ctx->fd,keyname,keylen) != (ssize_t)keylen) return 0;
     if (write(ctx->fd,&type,sizeof(type)) != sizeof(type)) return 0;
     if (write(ctx->fd,val,len) != (ssize_t)len) return 0;
-    gguf_remap(ctx);
+    if (gguf_remap(ctx) == 0) return 0;
     ctx->header->metadata_kv_count++;
     return 1;
 }
@@ -479,7 +479,7 @@ int gguf_append_tensor_info(gguf_ctx *ctx, const char *tensorname, uint64_t name
     }
     if (write(ctx->fd,&type,sizeof(type)) != sizeof(type)) return 0;
     if (write(ctx->fd,&offset,sizeof(offset)) != sizeof(offset)) return 0;
-    gguf_remap(ctx);
+    if (gguf_remap(ctx) == 0) return 0;
     ctx->header->tensor_count++;
     return 1;
 }
@@ -494,7 +494,7 @@ int gguf_append_tensor_data(gguf_ctx *ctx, void *tensor, uint64_t tensor_size) {
     uint64_t padding = gguf_get_alignment_padding(ctx->alignment,ctx->size);
     if (write(ctx->fd,padding_data,padding) != (ssize_t)padding) return 0;
     if (write(ctx->fd,tensor,tensor_size) != (ssize_t)tensor_size) return 0;
-    gguf_remap(ctx);
+    if (gguf_remap(ctx) == 0) return 0;
     return 1;
 }
 


### PR DESCRIPTION
`gguf_remap` returns 0 on error, but this is currently not checked when appending kv, info, or tensor data.