### PR TITLE
Print tensor dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ tokenizer.ggml.tokens: [array] [!, ", #, $, %, &, ', (, ), *, +, ,, -, ., /, 0, 
 
 ... many more key-value pairs ...
 
-q8_0 tensor token_embd.weight @1806176, 131072000 weights, 139264000 bytes
-f32 tensor blk.0.attn_norm.bias @141070176, 2560 weights, 10240 bytes
-f32 tensor blk.0.attn_norm.weight @141080416, 2560 weights, 10240 bytes
-f32 tensor blk.0.attn_qkv.bias @141090656, 7680 weights, 30720 bytes
-q8_0 tensor blk.0.attn_qkv.weight @141121376, 19660800 weights, 20889600 bytes
-f32 tensor blk.0.attn_output.bias @162010976, 2560 weights, 10240 bytes
-q8_0 tensor blk.0.attn_output.weight @162021216, 6553600 weights, 6963200 bytes
-f32 tensor blk.0.ffn_up.bias @168984416, 10240 weights, 40960 bytes
+q8_0 tensor token_embd.weight @1806176, 131072000 weights, dims [2560,51200], 139264000 bytes
+f32 tensor blk.0.attn_norm.bias @141070176, 2560 weights, dims [2560], 10240 bytes
+f32 tensor blk.0.attn_norm.weight @141080416, 2560 weights, dims [2560], 10240 bytes
+f32 tensor blk.0.attn_qkv.bias @141090656, 7680 weights, dims [7680], 30720 bytes
+q8_0 tensor blk.0.attn_qkv.weight @141121376, 19660800 weights, dims [2560,7680], 20889600 bytes
+f32 tensor blk.0.attn_output.bias @162010976, 2560 weights, dims [2560], 10240 bytes
+q8_0 tensor blk.0.attn_output.weight @162021216, 6553600 weights, dims [2560,2560], 6963200 bytes
+f32 tensor blk.0.ffn_up.bias @168984416, 10240 weights, dims [10240], 40960 bytes
 
 ... many more tensors ...
 ```

--- a/gguf-tools.c
+++ b/gguf-tools.c
@@ -166,13 +166,17 @@ void gguf_tools_show(const char *filename) {
     gguf_tensor tensor;
     uint64_t params = 0;
     while (gguf_get_tensor(ctx,&tensor)) {
-        printf("%s tensor %.*s @%llu, %llu weights, %llu bytes\n",
+        printf("%s tensor %.*s @%llu, %llu weights, dims ",
             gguf_get_tensor_type_name(tensor.type),
             (int)tensor.namelen,
             tensor.name,
             tensor.offset,
-            tensor.num_weights,
-            tensor.bsize);
+            tensor.num_weights);
+        for (uint32_t j = 0; j < tensor.ndim; j++) {
+            printf("%s%llu",(j == 0) ? "[" : ",", tensor.dim[j]);
+        }
+        printf("], %llu bytes\n", tensor.bsize);
+
         params += tensor.num_weights;
     }
     printf("gguf-tools.info.parameters: %.02fB\n",


### PR DESCRIPTION
This may be useful to debug a model. The format looks like this:

```
q8_0 tensor token_embd.weight @1806176, 131072000 weights, dims [2560,51200], 139264000 bytes
```

Let me know if you prefer `dimensions` or `shape` instead of `dims`.