### PR TITLE
Print tensor with correct strides

### DIFF
--- a/gguf-tools.c
+++ b/gguf-tools.c
@@ -368,7 +368,7 @@ void gguf_tools_inspect_weights(const char *filename, const char *tname, uint64_
     uint64_t strides[GGUF_TENSOR_MAX_DIM] = {0};
     strides[tensor.ndim-1] = 1;
     for (int j = tensor.ndim - 2; j >= 0; j--) {
-        strides[j] = tensor.dim[j + 1] * strides[j + 1];
+        strides[j] = tensor.dim[tensor.ndim - 2 - j] * strides[j + 1];
     }
 
     const int ident = 4;


### PR DESCRIPTION
Follow up to fix the stride order implemented in https://github.com/antirez/gguf-tools/pull/5

I used these two models:

```bash
$ wget https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0/resolve/main/model.safetensors
$ wget https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.Q8_0.gguf -O model.gguf
```

Inspect safetensors with python:

```python
In [1]: from safetensors.torch import load_file

In [2]: t = load_file("model.safetensors")

In [5]: t['model.layers.0.self_attn.v_proj.weight']
Out[5]:
tensor([[ 0.0281,  0.0059, -0.0003,  ...,  0.0025, -0.0121, -0.0046],
        [ 0.0176,  0.0092, -0.0009,  ..., -0.0043, -0.0023,  0.0128],
        [ 0.0359,  0.0053,  0.0016,  ...,  0.0078, -0.0013,  0.0157],
        ...,
        [-0.0178,  0.0039,  0.0020,  ..., -0.0052,  0.0037,  0.0068],
        [-0.0164,  0.0214, -0.0201,  ..., -0.0388,  0.0011,  0.0055],
        [ 0.0199,  0.0117, -0.0021,  ..., -0.0103,  0.0130,  0.0123]],
       dtype=torch.bfloat16)
```

Inspect gguf with gguf-tools:

```
 $ ./gguf-tools inspect-tensor model.gguf blk.0.attn_v.weight | grep "\[" -A 1 -B 2 | head -n 15
[
        0.027960, 0.006053, -0.000288, -0.005477,
--
        0.000969, 0.002423, -0.012115, -0.004684,
],
[
        0.017620, 0.009238, -0.000855, 0.009751,
--
        -0.002385, -0.004350, -0.002385, 0.012768,
],
[
        0.035881, 0.005368, 0.001695, -0.000848,
--
        -0.001723, 0.007832, -0.001253, 0.015821,
],
```

We can confirm that the first three and last three values of the first three rows are approximately equal.
