### PR TITLE
Fix q4_1 dequantization

### DIFF
--- a/gguflib.c
+++ b/gguflib.c
@@ -834,7 +834,7 @@ void gguf_q4_1_to_float(void *weights_data, void *dst, uint64_t count, store_flo
         /* For each block get the scale and convert all the
          * weights in the block. */
         float scale = from_half(*((uint16_t*)block));
-        float bias = from_half(*((uint16_t*)block+2));
+        float bias = from_half(*((uint16_t*)block+1));
         /* First 16 weights are in the lower bits */
         for (uint32_t j = 0; j < 16; j++) {
             uint8_t value = block[j+4]; // j+2 to skip the scale and bias bytes.


### PR DESCRIPTION
Fixes a bug I introduced in https://github.com/antirez/gguf-tools/pull/8 (sorry!)

Testing: I downloaded `tinyllama-1.1b-chat-v1.0.f16.gguf` from https://huggingface.co/jartine/TinyLlama-1.1B-Chat-v1.0-GGUF/tree/main and quantized it to Q4_1 using llama.cpp

```
➜  gguf-tools git:(q4_1_fix) ✗ ./gguf-tools compare models/tinyllama-1.1b-chat-v1.0.{f16,Q4_1}.gguf | head
[output.weight]: avg weights difference: 1.434430%
[token_embd.weight]: avg weights difference: 6.100484%
[blk.0.attn_norm.weight]: avg weights difference: 0.000000%
[blk.0.ffn_down.weight]: avg weights difference: 6.222765%
[blk.0.ffn_gate.weight]: avg weights difference: 6.180739%
[blk.0.ffn_up.weight]: avg weights difference: 6.132700%
[blk.0.ffn_norm.weight]: avg weights difference: 0.000000%
[blk.0.attn_k.weight]: avg weights difference: 10.652225%
[blk.0.attn_output.weight]: avg weights difference: 6.446345%
[blk.0.attn_q.weight]: avg weights difference: 9.062141%
```

For comparison, these are the Q4_0 differences:

```
➜  gguf-tools git:(q4_1_fix) ✗ ./gguf-tools compare models/tinyllama-1.1b-chat-v1.0.{f16,Q4_0}.gguf | head
[output.weight]: avg weights difference: 1.434458%
[token_embd.weight]: avg weights difference: 6.803601%
[blk.0.attn_norm.weight]: avg weights difference: 0.000000%
[blk.0.ffn_down.weight]: avg weights difference: 6.983525%
[blk.0.ffn_gate.weight]: avg weights difference: 6.957460%
[blk.0.ffn_up.weight]: avg weights difference: 6.854200%
[blk.0.ffn_norm.weight]: avg weights difference: 0.000000%
[blk.0.attn_k.weight]: avg weights difference: 13.007496%
[blk.0.attn_output.weight]: avg weights difference: 7.391561%
[blk.0.attn_q.weight]: avg weights difference: 10.883575%
```