### PR TITLE
Add IQ2 tensor types

### DIFF
--- a/gguflib.h
+++ b/gguflib.h
@@ -34,6 +34,10 @@ enum gguf_tensor_type {
     GGUF_TYPE_Q5_K = 13,
     GGUF_TYPE_Q6_K = 14,
     GGUF_TYPE_Q8_K = 15,
+    // IQ2 quants
+    GGML_TYPE_IQ2_XXS = 16,
+    GGML_TYPE_IQ2_XS  = 17,
+    // Integer quants
     GGUF_TYPE_I8,
     GGUF_TYPE_I16,
     GGUF_TYPE_I32,


### PR DESCRIPTION
[These](https://github.com/ggerganov/llama.cpp/blob/7dcbe39d36b76389f6c5cd3b151928472b7e22ff/ggml.h#L354-L355) were added in https://github.com/ggerganov/llama.cpp/pull/4773

It's annoying that I8 used to be 16 and it's now 18. I16 and I32 also changed.

[Dequantization code is very cryptic](https://github.com/ggerganov/llama.cpp/blob/9ecdd12e95aee20d6dfaf5f5a0f0ce5ac1fb2747/ggml-quants.c#L3457-L3508). I would love to see your take :)  