### PR TITLE
Match key-value pair and tensor counts with header integer width

### DIFF
--- a/gguflib.h
+++ b/gguflib.h
@@ -152,8 +152,8 @@ typedef struct {
     uint8_t *data;  // Memory mapped data.
     uint64_t size;  // Total file size.
     struct gguf_header *header;     // GUFF file header info.
-    uint32_t left_kv;               // Number of key-value pairs yet to read.
-    uint32_t left_tensors;          // Number of tensors yet to read.
+    uint64_t left_kv;               // Number of key-value pairs yet to read.
+    uint64_t left_tensors;          // Number of tensors yet to read.
     uint64_t off;                   // Offset of the next item to parse.
     uint64_t data_off;              // Offset of tensor data section. This
                                     // is only set when all the kv/tensor header


### PR DESCRIPTION
Update `left_kv` and `left_tensors` to match the 64-bit integers used in `struct gguf_header`, eliminating implicit 64-bit to 32-bit conversions.